### PR TITLE
Update TLS support for LS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,5 @@ scenarios/*.nohup
 scenarios/*/appexec/*
 scenarios/logs/*
 cluster_deploy/ext_tools/jaegar/jaeger_port_forward.nohup
-scenarios/*/client.conf
+scenarios/*/*.conf
+scenarios/*/*.crt

--- a/application_code/client_apps/java/nat_cons/src/main/java/com/example/pulsarworkshop/nat_cons/NatConsCmdApp.java
+++ b/application_code/client_apps/java/nat_cons/src/main/java/com/example/pulsarworkshop/nat_cons/NatConsCmdApp.java
@@ -106,19 +106,11 @@ public class NatConsCmdApp extends PulsarWorkshopCmdApp {
 
     @Override
     public void runApp() {
-
-
-        PulsarExtraCfgConf extraCfgConf = null;
-        if (extraCfgConf != null) {
-            extraCfgConf = new PulsarExtraCfgConf(clientConfigFile);
-        }
-
         try {
             pulsarClient = createNativePulsarClient();
             pulsarConsumer = createPulsarConsumer(
                     pulsarTopicName,
                     pulsarClient,
-                    extraCfgConf,
                     subsriptionName,
                     subscriptionType);
 

--- a/application_code/client_apps/java/nat_prod/src/main/java/com/example/pulsarworkshop/nat_prod/NatProdCmdApp.java
+++ b/application_code/client_apps/java/nat_prod/src/main/java/com/example/pulsarworkshop/nat_prod/NatProdCmdApp.java
@@ -112,15 +112,9 @@ public class NatProdCmdApp extends PulsarWorkshopCmdApp {
 
     @Override
     public void runApp() throws WorkshopRuntimException {
-
-        PulsarExtraCfgConf extraCfgConf = null;
-        if (extraCfgConf != null) {
-            extraCfgConf = new PulsarExtraCfgConf(clientConfigFile);
-        }
-
         try {
             pulsarClient = createNativePulsarClient();
-            pulsarProducer = createPulsarProducer(pulsarTopicName, pulsarClient, extraCfgConf);
+            pulsarProducer = createPulsarProducer(pulsarTopicName, pulsarClient);
 
             // TODO: right now the message is sent as byte[].
             //       add support for more complex types likes 'avro' or 'json' in the future.

--- a/cluster_deploy/pulsar/deploy_pulsar_cluster.sh
+++ b/cluster_deploy/pulsar/deploy_pulsar_cluster.sh
@@ -233,6 +233,13 @@ if [[ -d "${targetClntConfFileFolder}" ]]; then
         echo "authParams=token:${jwtTokenStr}" >> ${clntConnFile}
     fi
 
+    if [[ "${helmTlsEnabled}" == "true" ]]; then
+        caCertStr=$(kubectl get secrets pulsar-tls -o jsonpath="{.data['ca\.crt']}" | base64 --decode)
+        caCertFile="${targetClntConfFileFolder}/ca.crt"
+        echo "${caCertStr}" > ${caCertFile}
+        echo "tlsTrustCertsFilePath=${caCertFile}" >> ${clntConnFile}
+    fi
+
 fi
 
 echo

--- a/scenarios/deployScenario.sh
+++ b/scenarios/deployScenario.sh
@@ -282,6 +282,10 @@ for appId in "${scnAppIdArr[@]}"; do
    appClass=${appDefArr[2]}
    appParam=${appDefArr[3]}
 
+   if [[ "${useAstraStreaming}" == "yes" ]]; then
+      appParam="-as ${appParam}"
+   fi
+
    #
    # TBD: currently this only support java demo applications
    #      add support for other languages in the future


### PR DESCRIPTION
When connecting to Astra Streaming, there is no need to specify `tlsTrustCertsFilePath` parameter. But for Luna Streaming, we have to specify this parameter.
1) Update `PulsarWorkshopCmdApp` to add a new optional CLI option `-as` or `-astra` (without value) to indicate if Astra Streaming is the target Pulsar cluster. If not specified (default), it indicates that the target cluster is Luna Streaming based.
2) Update the script file to support generating `tlsTrustCertsFilePath` properly from K8s secret. 