### PR TITLE
Add S4R Queue clients - basic functions

### DIFF
--- a/application_code/client_apps/java/s4r_rabbitmq_queue_consumer/pom.xml
+++ b/application_code/client_apps/java/s4r_rabbitmq_queue_consumer/pom.xml
@@ -43,5 +43,15 @@
             <artifactId>common-resources</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.pulsar</groupId>
+            <artifactId>pulsar-client</artifactId>
+            <version>${pulsar.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.rabbitmq</groupId>
+            <artifactId>amqp-client</artifactId>
+            <version>4.0.0</version>
+        </dependency>        
     </dependencies>
 </project>

--- a/application_code/client_apps/java/s4r_rabbitmq_queue_consumer/src/main/java/com/example/pulsarworkshop/S4RQueueConsumer.java
+++ b/application_code/client_apps/java/s4r_rabbitmq_queue_consumer/src/main/java/com/example/pulsarworkshop/S4RQueueConsumer.java
@@ -1,0 +1,89 @@
+package com.example.pulsarworkshop;
+import com.example.pulsarworkshop.common.PulsarWorkshopCmdApp;
+import com.example.pulsarworkshop.common.exception.InvalidParamException;
+import com.example.pulsarworkshop.common.exception.WorkshopRuntimException;
+import org.apache.commons.cli.Option;
+import org.apache.pulsar.shade.org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import com.rabbitmq.client.AMQP;
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.ConnectionFactory;
+import com.rabbitmq.client.DefaultConsumer;
+import com.rabbitmq.client.Envelope;
+import com.rabbitmq.client.Connection;
+import java.io.IOException;
+import java.util.concurrent.TimeoutException;
+
+public class S4RQueueConsumer extends PulsarWorkshopCmdApp {
+    private final static Logger logger = LoggerFactory.getLogger(S4RQueueConsumer.class);
+    int S4RPort = 5672;
+    String S4RQueueName = "s4r-default-queue";
+    ConnectionFactory S4RFactory;
+    Connection connection;
+    Channel channel;
+    DefaultConsumer consumer;
+
+    public S4RQueueConsumer(String[] inputParams) {
+        super(inputParams);
+        addCommandLineOption(new Option("s4rport", "s4rport", true, "S4R Pulsar RabbitMQ port number."));
+        addCommandLineOption(new Option("q", "s4rqueue", true, "S4R Pulsar RabbitMQ queue name."));
+    }
+
+    public static void main(String[] args) {
+        PulsarWorkshopCmdApp workshopApp = new S4RQueueConsumer(args);
+
+        int exitCode = workshopApp.run("S4RQueueConsumer");
+
+        System.exit(exitCode);
+    }
+
+    @Override
+    public void processInputParams() throws InvalidParamException {
+        S4RPort = processIntegerInputParam("s4rport");
+    	if ( S4RPort <= 0  ) {
+    		throw new InvalidParamException("S4RPort number must be a positive integer.  Default is 5672");
+    	}
+        S4RQueueName = processStringInputParam("s4rqueue");
+        if (StringUtils.isBlank(S4RQueueName)) {
+            S4RQueueName = "s4r-default-queue";
+        }
+    }
+
+    @Override
+    public void runApp() {
+        try {
+            S4RFactory= new ConnectionFactory();
+            S4RFactory.setHost("localhost");
+            S4RFactory.setPort(S4RPort);
+            connection = S4RFactory.newConnection();
+            channel = connection.createChannel();
+            channel.queueDeclare(S4RQueueName, true, false, false, null);
+            consumer = new DefaultConsumer(channel) {
+                @Override
+                 public void handleDelivery(String consumerTag, Envelope envelope, AMQP.BasicProperties properties, byte[] body) throws IOException {
+                        String message = new String(body, "UTF-8");
+                    // process the message
+//                        System.out.println("message is: " + message);
+                        logger.info("SR4 Consumer received message : " + message);
+                 }
+            };
+            channel.basicConsume(S4RQueueName, true, consumer);
+            logger.info("SR4 Consumer created for queue " + S4RQueueName);
+        } catch (Exception e) {
+            throw new WorkshopRuntimException("Unexpected error when consuming S4R messages: " + e.getMessage());   
+        }
+    }
+
+    @Override
+    public void termApp() {
+        try {
+            channel.close();
+            connection.close();
+        } catch (IOException ioe) {
+            throw new WorkshopRuntimException("Unexpected error when shutting down S4R Queue Producer IO Exception: " + ioe.getMessage());  
+        } catch (TimeoutException te) {
+            throw new WorkshopRuntimException("Unexpected error when shutting down S4R Queue Producer Timeout Exception: " + te.getMessage());  
+        }
+    }
+}

--- a/application_code/client_apps/java/s4r_rabbitmq_queue_consumer/src/main/resources/logback.xml
+++ b/application_code/client_apps/java/s4r_rabbitmq_queue_consumer/src/main/resources/logback.xml
@@ -1,0 +1,11 @@
+<configuration debug="false">
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="debug">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/application_code/client_apps/java/s4r_rabbitmq_queue_producer/pom.xml
+++ b/application_code/client_apps/java/s4r_rabbitmq_queue_producer/pom.xml
@@ -46,6 +46,11 @@
             <artifactId>common-resources</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.rabbitmq</groupId>
+            <artifactId>amqp-client</artifactId>
+            <version>4.0.0</version>
+        </dependency>        
     </dependencies>
 
 </project>

--- a/application_code/client_apps/java/s4r_rabbitmq_queue_producer/src/main/java/com/example/pulsarworkshop/S4RQueueProducer.java
+++ b/application_code/client_apps/java/s4r_rabbitmq_queue_producer/src/main/java/com/example/pulsarworkshop/S4RQueueProducer.java
@@ -16,14 +16,16 @@ public class S4RQueueProducer extends PulsarWorkshopCmdApp {
     private final static Logger logger = LoggerFactory.getLogger(S4RQueueProducer.class);
     int S4RPort = 5672;
     String S4RQueueName = "s4r-default-queue";
+    String S4RMessage = "This is a RabbitMQ message ******** Msg num: ";
     ConnectionFactory S4RFactory;
     Connection connection;
     Channel channel;
 
     public S4RQueueProducer(String[] inputParams) {
         super(inputParams);
-        addCommandLineOption(new Option("s4rport", "s4rport", true, "S4R Pulsar RabbitMQ port number."));
+        addCommandLineOption(new Option("p", "s4rport", true, "S4R Pulsar RabbitMQ port number, default is 5672"));
         addCommandLineOption(new Option("q", "s4rqueue", true, "S4R Pulsar RabbitMQ queue name."));
+        addCommandLineOption(new Option("m", "s4rmessage", true, "S4R Pulsar RabbitMQ message to send, otherwise a default is used."));
     }
     public static void main(String[] args) {
         PulsarWorkshopCmdApp workshopApp = new S4RQueueProducer(args);
@@ -39,9 +41,13 @@ public class S4RQueueProducer extends PulsarWorkshopCmdApp {
     	if ( S4RPort <= 0  ) {
     		throw new InvalidParamException("S4RPort number must be a positive integer.  Default is 5672");
     	}
-        S4RQueueName = processStringInputParam("s4rqueue");
-        if (StringUtils.isBlank(S4RQueueName)) {
-            S4RQueueName = "s4r-default-queue";
+       String queueName = processStringInputParam("s4rqueue");
+        if (!StringUtils.isBlank(queueName)) {
+            S4RQueueName = queueName;
+        }
+        String msgToSend = processStringInputParam("s4rmessage");
+        if (!StringUtils.isBlank(msgToSend)) {
+            S4RMessage = msgToSend;
         }
     }
 
@@ -57,7 +63,7 @@ public class S4RQueueProducer extends PulsarWorkshopCmdApp {
             channel.queueDeclare(S4RQueueName, true, false, false, null);
             int msgSent = 0;
             while (numMsg > msgSent) {
-                String message = "This is the RabbitMQ message ******** Msg num: " + msgSent; 
+                String message = S4RMessage; 
                 channel.basicPublish("", S4RQueueName, null, message.getBytes());
                 if (logger.isDebugEnabled()) {
                     logger.debug("Published a message: {}", msgSent);

--- a/application_code/client_apps/java/s4r_rabbitmq_queue_producer/src/main/java/com/example/pulsarworkshop/S4RQueueProducer.java
+++ b/application_code/client_apps/java/s4r_rabbitmq_queue_producer/src/main/java/com/example/pulsarworkshop/S4RQueueProducer.java
@@ -1,0 +1,84 @@
+package com.example.pulsarworkshop;
+import org.apache.commons.cli.Option;
+import org.apache.pulsar.shade.org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import com.example.pulsarworkshop.common.PulsarWorkshopCmdApp;
+import com.example.pulsarworkshop.common.exception.InvalidParamException;
+import com.example.pulsarworkshop.common.exception.WorkshopRuntimException;
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.ConnectionFactory;
+import com.rabbitmq.client.Connection;
+import java.io.IOException;
+import java.util.concurrent.TimeoutException;
+
+public class S4RQueueProducer extends PulsarWorkshopCmdApp {
+    private final static Logger logger = LoggerFactory.getLogger(S4RQueueProducer.class);
+    int S4RPort = 5672;
+    String S4RQueueName = "s4r-default-queue";
+    ConnectionFactory S4RFactory;
+    Connection connection;
+    Channel channel;
+
+    public S4RQueueProducer(String[] inputParams) {
+        super(inputParams);
+        addCommandLineOption(new Option("s4rport", "s4rport", true, "S4R Pulsar RabbitMQ port number."));
+        addCommandLineOption(new Option("q", "s4rqueue", true, "S4R Pulsar RabbitMQ queue name."));
+    }
+    public static void main(String[] args) {
+        PulsarWorkshopCmdApp workshopApp = new S4RQueueProducer(args);
+
+        int exitCode = workshopApp.run("S4RQueueProducer");
+
+        System.exit(exitCode);
+    }
+
+    @Override
+    public void processInputParams() throws InvalidParamException {
+        S4RPort = processIntegerInputParam("s4rport");
+    	if ( S4RPort <= 0  ) {
+    		throw new InvalidParamException("S4RPort number must be a positive integer.  Default is 5672");
+    	}
+        S4RQueueName = processStringInputParam("s4rqueue");
+        if (StringUtils.isBlank(S4RQueueName)) {
+            S4RQueueName = "s4r-default-queue";
+        }
+    }
+
+    @Override
+    public void runApp() {
+        try {
+            S4RFactory= new ConnectionFactory();
+            S4RFactory.setHost("localhost");
+            S4RFactory.setPort(S4RPort);
+            connection = S4RFactory.newConnection();
+            channel = connection.createChannel();
+            channel.confirmSelect();
+            channel.queueDeclare(S4RQueueName, true, false, false, null);
+            int msgSent = 0;
+            while (numMsg > msgSent) {
+                String message = "This is the RabbitMQ message ******** Msg num: " + msgSent; 
+                channel.basicPublish("", S4RQueueName, null, message.getBytes());
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Published a message: {}", msgSent);
+                }
+                msgSent++;
+                channel.waitForConfirmsOrDie(5000);  //basically flush after each message published
+            }
+        } catch (Exception e) {
+            throw new WorkshopRuntimException("Unexpected error when producing S4R messages: " + e.getMessage());  
+        }
+    }
+
+    @Override
+    public void termApp() {
+        try {
+            channel.close();
+            connection.close();
+        } catch (IOException ioe) {
+            throw new WorkshopRuntimException("Unexpected error when shutting down S4R Queue Producer IO Exception: " + ioe.getMessage());  
+        } catch (TimeoutException te) {
+            throw new WorkshopRuntimException("Unexpected error when shutting down S4R Queue Producer Timeout Exception: " + te.getMessage());  
+        }
+    }
+}

--- a/application_code/client_apps/java/s4r_rabbitmq_queue_producer/src/main/resources/logback.xml
+++ b/application_code/client_apps/java/s4r_rabbitmq_queue_producer/src/main/resources/logback.xml
@@ -1,0 +1,11 @@
+<configuration debug="false">
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="debug">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>


### PR DESCRIPTION
Initial cut of S4R Queue clients, RabbitMQ Producer and Consumers.  Assumptions:   Localhost Pulsar cluster running with S4R  protocol handlers install and enabled.

TODOs:
Add scenario and app_def.properties for deployScenario.sh script 
Add and parse Astra and other RabbitMQ config options
Add README
